### PR TITLE
fix: created folder should not contain ext

### DIFF
--- a/kudu/__init__.py
+++ b/kudu/__init__.py
@@ -1,3 +1,3 @@
-__version__ = '0.15'
+__version__ = '0.16'
 __author__ = 'Joshua Heller'
 __email__ = 'joshua@torfeld6.com'

--- a/kudu/commands/create.py
+++ b/kudu/commands/create.py
@@ -14,7 +14,9 @@ from kudu.commands.push import get_file_data, update_file_metadata
 @click.option('--extension', '-e', type=str, required=False, default="zip", help="Extension of the file that's going to be uploaded, default 'zip'")
 @click.pass_context
 def create(ctx, instance, body, filename = None, path = None, extension = "zip"):
-    file_data = get_file_data(path, filename or '%i%s' % (int(round(time.time() * 1000)), extension), category=extension)
+    base_name, _ = os.path.splitext(filename or '%i.%s' % (int(round(time.time() * 1000)), extension))
+    
+    file_data = get_file_data(path, base_name, category=extension)
     file_id = create_file(ctx.obj['token'], instance, body, extension, filename=filename)
     url = '/files/%d/upload-url/' % file_id
     response = request('get', url, token=ctx.obj['token'])

--- a/kudu/commands/create.py
+++ b/kudu/commands/create.py
@@ -14,7 +14,7 @@ from kudu.commands.push import get_file_data, update_file_metadata
 @click.option('--extension', '-e', type=str, required=False, default="zip", help="Extension of the file that's going to be uploaded, default 'zip'")
 @click.pass_context
 def create(ctx, instance, body, filename = None, path = None, extension = "zip"):
-    base_name, _ = os.path.splitext(filename or '%i.%s' % (int(round(time.time() * 1000)), extension))
+    base_name = os.path.splitext(filename)[0] if filename else str(int(round(time.time() * 1000)))
     
     file_data = get_file_data(path, base_name, category=extension)
     file_id = create_file(ctx.obj['token'], instance, body, extension, filename=filename)


### PR DESCRIPTION
if the created folders contain extensions in their names the uploaded folders inside the zips also contain the `.zip` extension.